### PR TITLE
Update integer.js

### DIFF
--- a/src/validators/integer.js
+++ b/src/validators/integer.js
@@ -1,2 +1,2 @@
 import { regex } from './common'
-export default regex('integer', /^-?[0-9]*$/)
+export default regex('integer', /^-?[0-9]+$/)


### PR DESCRIPTION
Previously, the valid value was the string `-`. Now there must be at least 1 figure