### PR TITLE
Fix integer regex

### DIFF
--- a/src/validators/integer.js
+++ b/src/validators/integer.js
@@ -1,2 +1,4 @@
 import { regex } from './common'
-export default regex('integer', /^-?[0-9]*$/)
+// ^[0-9]*$ - for empty string and positive integer
+// ^-[0-9]+$ - only for negative integer (minus sign without at least 1 digit is not a number)
+export default regex('integer', /(^[0-9]*$)|(^-[0-9]+$)/)


### PR DESCRIPTION
The previous regular expression returned an incorrect response when the argument was the next line: `-`